### PR TITLE
Level up!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "textwidth"
-version = "1.1.0"
+version = "1.2.0"
 description = "Get the width of a piece of text for a font through xlib"
 authors = ["Marcel Müller <neikos@neikos.email>"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,5 @@ authors = ["Marcel Müller <neikos@neikos.email>"]
 license = "MIT"
 edition = "2018"
 
-[dependencies.x11]
-version = "2.18.0"
-features = ["xlib"]
+[dependencies]
+x11 = { version = "2.18.2", features = ["xlib"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,10 @@
 [package]
-authors = ["Marcel Müller <neikos@neikos.email>"]
 name = "textwidth"
 version = "1.1.0"
 description = "Get the width of a piece of text for a font through xlib"
+authors = ["Marcel Müller <neikos@neikos.email>"]
 license = "MIT"
-
-
-[dependencies]
-failure = "0.1.1"
+edition = "2018"
 
 [dependencies.x11]
 version = "2.18.0"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,6 @@
+edition = "2018"
+max_width = 80
+newline_style = "Unix"
+hard_tabs = true
+tab_spaces = 4
+use_field_init_shorthand = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,5 @@
 edition = "2018"
 max_width = 80
 newline_style = "Unix"
-hard_tabs = true
 tab_spaces = 4
 use_field_init_shorthand = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,131 +10,131 @@ use x11::xlib;
 struct XError(String);
 
 impl fmt::Display for XError {
-	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "X Error: {}", self.0)
-	}
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "X Error: {}", self.0)
+    }
 }
 
 impl Error for XError {}
 
 enum Data {
-	FontSet {
-		display: *mut xlib::Display,
-		fontset: xlib::XFontSet,
-	},
-	XFont {
-		display: *mut xlib::Display,
-		xfont: *mut xlib::XFontStruct,
-	},
+    FontSet {
+        display: *mut xlib::Display,
+        fontset: xlib::XFontSet,
+    },
+    XFont {
+        display: *mut xlib::Display,
+        xfont: *mut xlib::XFontStruct,
+    },
 }
 
 /// A context, holding the internal data required to query a string
 pub struct Context {
-	data: Data,
+    data: Data,
 }
 
 impl Context {
-	/// Creates a new context given by the font string given here.
-	///
-	/// The font string should be of the X11 form, as selected by `fontsel`.
-	/// XFT is not supported!
-	pub fn new(name: &str) -> Result<Self, Box<dyn Error>> {
-		unsafe {
-			let name: CString = CString::new(name)?;
-			let dpy = xlib::XOpenDisplay(ptr::null());
-			if dpy.is_null() {
-				return Err(Box::new(XError("Could not open display".into())));
-			}
-			let mut missing_ptr = MaybeUninit::uninit();
-			let mut missing_len = MaybeUninit::uninit();
-			let fontset = xlib::XCreateFontSet(
-				dpy,
-				name.as_ptr(),
-				missing_ptr.as_mut_ptr(),
-				missing_len.as_mut_ptr(),
-				ptr::null_mut(),
-			);
-			if !missing_ptr.assume_init().is_null() {
-				xlib::XFreeStringList(missing_ptr.assume_init());
-			}
-			if !fontset.is_null() {
-				Ok(Context {
-					data: Data::FontSet {
-						display: dpy,
-						fontset,
-					},
-				})
-			} else {
-				let xfont = xlib::XLoadQueryFont(dpy, name.as_ptr());
-				if xfont.is_null() {
-					xlib::XCloseDisplay(dpy);
-					Err(Box::new(XError(format!(
-						"Could not load font: {:?}",
-						name
-					))))
-				} else {
-					Ok(Context {
-						data: Data::XFont {
-							display: dpy,
-							xfont,
-						},
-					})
-				}
-			}
-		}
-	}
+    /// Creates a new context given by the font string given here.
+    ///
+    /// The font string should be of the X11 form, as selected by `fontsel`.
+    /// XFT is not supported!
+    pub fn new(name: &str) -> Result<Self, Box<dyn Error>> {
+        unsafe {
+            let name: CString = CString::new(name)?;
+            let dpy = xlib::XOpenDisplay(ptr::null());
+            if dpy.is_null() {
+                return Err(Box::new(XError("Could not open display".into())));
+            }
+            let mut missing_ptr = MaybeUninit::uninit();
+            let mut missing_len = MaybeUninit::uninit();
+            let fontset = xlib::XCreateFontSet(
+                dpy,
+                name.as_ptr(),
+                missing_ptr.as_mut_ptr(),
+                missing_len.as_mut_ptr(),
+                ptr::null_mut(),
+            );
+            if !missing_ptr.assume_init().is_null() {
+                xlib::XFreeStringList(missing_ptr.assume_init());
+            }
+            if !fontset.is_null() {
+                Ok(Context {
+                    data: Data::FontSet {
+                        display: dpy,
+                        fontset,
+                    },
+                })
+            } else {
+                let xfont = xlib::XLoadQueryFont(dpy, name.as_ptr());
+                if xfont.is_null() {
+                    xlib::XCloseDisplay(dpy);
+                    Err(Box::new(XError(format!(
+                        "Could not load font: {:?}",
+                        name
+                    ))))
+                } else {
+                    Ok(Context {
+                        data: Data::XFont {
+                            display: dpy,
+                            xfont,
+                        },
+                    })
+                }
+            }
+        }
+    }
 
-	/// Creates a new context with the misc-fixed font.
-	pub fn with_misc() -> Result<Self, Box<dyn Error>> {
-		Self::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*")
-	}
+    /// Creates a new context with the misc-fixed font.
+    pub fn with_misc() -> Result<Self, Box<dyn Error>> {
+        Self::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*")
+    }
 
-	/// Get text width for the given string
-	pub fn text_width<S: AsRef<str>>(&self, text: S) -> u64 {
-		get_text_width(&self, text)
-	}
+    /// Get text width for the given string
+    pub fn text_width<S: AsRef<str>>(&self, text: S) -> u64 {
+        get_text_width(&self, text)
+    }
 }
 
 impl Drop for Context {
-	fn drop(&mut self) {
-		unsafe {
-			match self.data {
-				Data::FontSet { display, fontset } => {
-					xlib::XFreeFontSet(display, fontset);
-					xlib::XCloseDisplay(display);
-				}
-				Data::XFont { display, xfont } => {
-					xlib::XFreeFont(display, xfont);
-					xlib::XCloseDisplay(display);
-				}
-			}
-		}
-	}
+    fn drop(&mut self) {
+        unsafe {
+            match self.data {
+                Data::FontSet { display, fontset } => {
+                    xlib::XFreeFontSet(display, fontset);
+                    xlib::XCloseDisplay(display);
+                }
+                Data::XFont { display, xfont } => {
+                    xlib::XFreeFont(display, xfont);
+                    xlib::XCloseDisplay(display);
+                }
+            }
+        }
+    }
 }
 
 /// Get the width of the text rendered with the font specified by the context
 pub fn get_text_width<S: AsRef<str>>(ctx: &Context, text: S) -> u64 {
-	let text = CString::new(text.as_ref()).expect("Could not create CString");
-	unsafe {
-		match ctx.data {
-			Data::FontSet { fontset, .. } => {
-				let mut rectangle = MaybeUninit::uninit();
-				xlib::XmbTextExtents(
-					fontset,
-					text.as_ptr(),
-					text.as_bytes().len() as i32,
-					ptr::null_mut(),
-					rectangle.as_mut_ptr(),
-				);
-				rectangle.assume_init().width as u64
-			}
-			Data::XFont { xfont, .. } => xlib::XTextWidth(
-				xfont,
-				text.as_ptr(),
-				text.as_bytes().len() as i32,
-			) as u64,
-		}
-	}
+    let text = CString::new(text.as_ref()).expect("Could not create CString");
+    unsafe {
+        match ctx.data {
+            Data::FontSet { fontset, .. } => {
+                let mut rectangle = MaybeUninit::uninit();
+                xlib::XmbTextExtents(
+                    fontset,
+                    text.as_ptr(),
+                    text.as_bytes().len() as i32,
+                    ptr::null_mut(),
+                    rectangle.as_mut_ptr(),
+                );
+                rectangle.assume_init().width as u64
+            }
+            Data::XFont { xfont, .. } => xlib::XTextWidth(
+                xfont,
+                text.as_ptr(),
+                text.as_bytes().len() as i32,
+            ) as u64,
+        }
+    }
 }
 
 /// Sets up xlib to be multithreaded
@@ -142,46 +142,46 @@ pub fn get_text_width<S: AsRef<str>>(ctx: &Context, text: S) -> u64 {
 /// Make sure you call this before doing __anything__ else xlib related.
 /// Also, do not call this more than once preferably
 pub fn setup_multithreading() {
-	unsafe {
-		xlib::XInitThreads();
-	}
+    unsafe {
+        xlib::XInitThreads();
+    }
 }
 
 #[cfg(test)]
 mod test {
-	use super::{get_text_width, Context};
-	use std::sync::Once;
-	use x11::xlib;
-	static SETUP: Once = Once::new();
-	// THIS MUST BE CALLED AT THE BEGINNING OF EACH TEST TO MAKE SURE THAT IT IS THREAD-SAFE!!!
-	fn setup() {
-		SETUP.call_once(|| unsafe {
-			xlib::XInitThreads();
-		})
-	}
-	#[test]
-	fn test_context_new() {
-		setup();
-		let ctx = Context::with_misc();
-		assert!(ctx.is_ok());
-	}
-	#[test]
-	fn test_context_drop() {
-		setup();
-		let ctx = Context::with_misc();
-		drop(ctx);
-		assert!(true);
-	}
-	#[test]
-	fn test_text_width() {
-		setup();
-		let ctx = Context::with_misc().unwrap();
-		assert!(get_text_width(&ctx, "Hello World") > 0);
-	}
-	#[test]
-	fn test_text_alternate() {
-		setup();
-		let ctx = Context::new("?");
-		assert!(ctx.is_err());
-	}
+    use super::{get_text_width, Context};
+    use std::sync::Once;
+    use x11::xlib;
+    static SETUP: Once = Once::new();
+    // THIS MUST BE CALLED AT THE BEGINNING OF EACH TEST TO MAKE SURE THAT IT IS THREAD-SAFE!!!
+    fn setup() {
+        SETUP.call_once(|| unsafe {
+            xlib::XInitThreads();
+        })
+    }
+    #[test]
+    fn test_context_new() {
+        setup();
+        let ctx = Context::with_misc();
+        assert!(ctx.is_ok());
+    }
+    #[test]
+    fn test_context_drop() {
+        setup();
+        let ctx = Context::with_misc();
+        drop(ctx);
+        assert!(true);
+    }
+    #[test]
+    fn test_text_width() {
+        setup();
+        let ctx = Context::with_misc().unwrap();
+        assert!(get_text_width(&ctx, "Hello World") > 0);
+    }
+    #[test]
+    fn test_text_alternate() {
+        setup();
+        let ctx = Context::new("?");
+        assert!(ctx.is_err());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ impl Context {
 	///
 	/// The font string should be of the X11 form, as selected by `fontsel`.
 	/// XFT is not supported!
-	pub fn new(name: &str) -> Result<Context, Box<dyn Error>> {
+	pub fn new(name: &str) -> Result<Self, Box<dyn Error>> {
 		unsafe {
 			let name: CString = CString::new(name)?;
 			let dpy = xlib::XOpenDisplay(ptr::null());
@@ -85,6 +85,13 @@ impl Context {
 				});
 			}
 		}
+	}
+
+	/// Creates a new context with the misc-fixed font.
+	pub fn with_misc() -> Result<Self, Box<dyn Error>> {
+		Self::new(
+			"-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*",
+        )
 	}
 
 	/// Get text width for the given string
@@ -162,26 +169,26 @@ mod test {
 	#[test]
 	fn test_context_new() {
 		setup();
-		let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*");
+		let ctx = Context::with_misc();
 		assert!(ctx.is_ok());
 	}
 	#[test]
 	fn test_context_drop() {
 		setup();
-		let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*");
+		let ctx = Context::with_misc();
 		drop(ctx);
 		assert!(true);
 	}
 	#[test]
 	fn test_text_width() {
 		setup();
-		let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*").unwrap();
+		let ctx = Context::with_misc().unwrap();
 		assert!(get_text_width(&ctx, "Hello World") > 0);
 	}
 	#[test]
 	fn test_text_alternate() {
 		setup();
-		let ctx = Context::new("basdkladslk");
+		let ctx = Context::new("?");
 		assert!(ctx.is_err());
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,127 +12,128 @@ use x11::xlib;
 struct XError(String);
 
 impl fmt::Display for XError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "X Error: {}", self.0)
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "X Error: {}", self.0)
+	}
 }
 
 impl Error for XError {}
 
 enum Data {
-    FontSet {
-        display: *mut xlib::Display,
-        fontset: xlib::XFontSet,
-    },
-    XFont {
-        display: *mut xlib::Display,
-        xfont: *mut xlib::XFontStruct,
-    },
+	FontSet {
+		display: *mut xlib::Display,
+		fontset: xlib::XFontSet,
+	},
+	XFont {
+		display: *mut xlib::Display,
+		xfont: *mut xlib::XFontStruct,
+	},
 }
 
 /// A context, holding the internal data required to query a string
 pub struct Context {
-    data: Data,
+	data: Data,
 }
 
 impl Context {
-    /// Creates a new context given by the font string given here.
-    ///
-    /// The font string should be of the X11 form, as selected by `fontsel`.
-    /// XFT is not supported!
-    pub fn new(name: &str) -> Result<Context, Box<dyn Error>> {
-        unsafe {
-            let name: CString = CString::new(name)?;
+	/// Creates a new context given by the font string given here.
+	///
+	/// The font string should be of the X11 form, as selected by `fontsel`.
+	/// XFT is not supported!
+	pub fn new(name: &str) -> Result<Context, Box<dyn Error>> {
+		unsafe {
+			let name: CString = CString::new(name)?;
+			let dpy = xlib::XOpenDisplay(ptr::null());
+			if dpy.is_null() {
+				return Err(Box::new(XError("Could not open display".into())));
+			}
+			let missing_ptr: *mut *mut c_char =
+				MaybeUninit::uninit().assume_init();
+			let missing_len: *mut c_int = MaybeUninit::uninit().assume_init();
+			let fontset = xlib::XCreateFontSet(
+				dpy,
+				name.as_ptr(),
+				mem::transmute(&missing_ptr),
+				mem::transmute(&missing_len),
+				ptr::null_mut(),
+			);
+			if !missing_ptr.is_null() {
+				xlib::XFreeStringList(missing_ptr);
+			}
+			if !fontset.is_null() {
+				return Ok(Context {
+					data: Data::FontSet {
+						display: dpy,
+						fontset,
+					},
+				});
+			} else {
+				let xfont = xlib::XLoadQueryFont(dpy, name.as_ptr());
+				if xfont.is_null() {
+					xlib::XCloseDisplay(dpy);
+					return Err(Box::new(XError(format!(
+						"Could not load font: {:?}",
+						name
+					))))?;
+				}
+				return Ok(Context {
+					data: Data::XFont {
+						display: dpy,
+						xfont,
+					},
+				});
+			}
+		}
+	}
 
-            let dpy = xlib::XOpenDisplay(ptr::null());
-            if dpy.is_null() {
-                return Err(Box::new(XError("Could not open display".into())));
-            }
-
-            let missing_ptr: *mut *mut c_char = MaybeUninit::uninit().assume_init();
-            let missing_len: *mut c_int = MaybeUninit::uninit().assume_init();
-            let fontset = xlib::XCreateFontSet(
-                dpy,
-                name.as_ptr(),
-                mem::transmute(&missing_ptr),
-                mem::transmute(&missing_len),
-                ptr::null_mut(),
-            );
-
-            if !missing_ptr.is_null() {
-                xlib::XFreeStringList(missing_ptr);
-            }
-
-            if !fontset.is_null() {
-                return Ok(Context {
-                    data: Data::FontSet {
-                        display: dpy,
-                        fontset: fontset,
-                    },
-                });
-            } else {
-                let xfont = xlib::XLoadQueryFont(dpy, name.as_ptr());
-
-                if xfont.is_null() {
-                    xlib::XCloseDisplay(dpy);
-                    return Err(Box::new(XError(format!("Could not load font: {:?}", name))))?;
-                }
-
-                return Ok(Context {
-                    data: Data::XFont {
-                        display: dpy,
-                        xfont: xfont,
-                    },
-                });
-            }
-        }
-    }
-
-    /// Get text width for the given string
-    pub fn text_width<S: AsRef<str>>(&self, text: S) -> u64 {
-        get_text_width(&self, text)
-    }
+	/// Get text width for the given string
+	pub fn text_width<S: AsRef<str>>(&self, text: S) -> u64 {
+		get_text_width(&self, text)
+	}
 }
 
 impl Drop for Context {
-    fn drop(&mut self) {
-        unsafe {
-            match self.data {
-                Data::FontSet { display, fontset } => {
-                    xlib::XFreeFontSet(display, fontset);
-                    xlib::XCloseDisplay(display);
-                }
-                Data::XFont { display, xfont } => {
-                    xlib::XFreeFont(display, xfont);
-                    xlib::XCloseDisplay(display);
-                }
-            }
-        }
-    }
+	fn drop(&mut self) {
+		unsafe {
+			match self.data {
+				Data::FontSet { display, fontset } => {
+					xlib::XFreeFontSet(display, fontset);
+					xlib::XCloseDisplay(display);
+				}
+				Data::XFont { display, xfont } => {
+					xlib::XFreeFont(display, xfont);
+					xlib::XCloseDisplay(display);
+				}
+			}
+		}
+	}
 }
 
 /// Get the width of the text rendered with the font specified by the context
 pub fn get_text_width<S: AsRef<str>>(ctx: &Context, text: S) -> u64 {
-    let text = CString::new(text.as_ref()).expect("Could not create cstring");
-
-    unsafe {
-        match ctx.data {
-            Data::FontSet { fontset, .. } => {
-                let mut r = MaybeUninit::uninit().assume_init();
-                xlib::XmbTextExtents(
-                    fontset,
-                    text.as_ptr(),
-                    text.as_bytes().len() as i32,
-                    ptr::null_mut(),
-                    &mut r,
-                );
-                return r.width as u64;
-            }
-            Data::XFont { xfont, .. } => {
-                return xlib::XTextWidth(xfont, text.as_ptr(), text.as_bytes().len() as i32) as u64;
-            }
-        }
-    }
+	let text = CString::new(text.as_ref()).expect("Could not create cstring");
+	unsafe {
+		match ctx.data {
+			Data::FontSet { fontset, .. } => {
+				let mut r = MaybeUninit::uninit().assume_init();
+				xlib::XmbTextExtents(
+					fontset,
+					text.as_ptr(),
+					text.as_bytes().len() as i32,
+					ptr::null_mut(),
+					&mut r,
+				);
+				return r.width as u64;
+			}
+			Data::XFont { xfont, .. } => {
+				return xlib::XTextWidth(
+					xfont,
+					text.as_ptr(),
+					text.as_bytes().len() as i32,
+				) as u64;
+			}
+		}
+	}
 }
 
 /// Sets up xlib to be multithreaded
@@ -140,53 +141,47 @@ pub fn get_text_width<S: AsRef<str>>(ctx: &Context, text: S) -> u64 {
 /// Make sure you call this before doing __anything__ else xlib related.
 /// Also, do not call this more than once preferably
 pub fn setup_multithreading() {
-    unsafe {
-        xlib::XInitThreads();
-    }
+	unsafe {
+		xlib::XInitThreads();
+	}
 }
 
 #[cfg(test)]
 mod test {
-    use super::{get_text_width, Context};
-    use std::sync::Once;
-    use x11::xlib;
+	use super::{get_text_width, Context};
+	use std::sync::Once;
+	use x11::xlib;
+	static SETUP: Once = Once::new();
+	// THIS MUST BE CALLED AT THE BEGINNING OF EACH TEST TO MAKE SURE THAT IT IS THREAD-SAFE!!!
+	fn setup() {
+		SETUP.call_once(|| unsafe {
+			xlib::XInitThreads();
+		})
+	}
+	#[test]
+	fn test_context_new() {
+		setup();
+		let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*");
+		assert!(ctx.is_ok());
+	}
+	#[test]
+	fn test_context_drop() {
+		setup();
+		let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*");
+		drop(ctx);
+		assert!(true);
+	}
+	#[test]
+	fn test_text_width() {
+		setup();
+		let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*").unwrap();
 
-    static SETUP: Once = Once::new();
-
-    // THIS MUST BE CALLED AT THE BEGINNING OF EACH TEST TO MAKE SURE THAT IT IS THREAD-SAFE!!!
-    fn setup() {
-        SETUP.call_once(|| unsafe {
-            xlib::XInitThreads();
-        })
-    }
-
-    #[test]
-    fn test_context_new() {
-        setup();
-        let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*");
-        assert!(ctx.is_ok());
-    }
-
-    #[test]
-    fn test_context_drop() {
-        setup();
-        let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*");
-        drop(ctx);
-        assert!(true);
-    }
-
-    #[test]
-    fn test_text_width() {
-        setup();
-        let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*").unwrap();
-
-        assert!(get_text_width(&ctx, "Hello World") > 0);
-    }
-
-    #[test]
-    fn test_text_alternate() {
-        setup();
-        let ctx = Context::new("basdkladslk");
-        assert!(ctx.is_err());
-    }
+		assert!(get_text_width(&ctx, "Hello World") > 0);
+	}
+	#[test]
+	fn test_text_alternate() {
+		setup();
+		let ctx = Context::new("basdkladslk");
+		assert!(ctx.is_err());
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::os::raw::{c_char, c_int};
 use std::ptr;
 use x11::xlib;
 
+/// XError holds the X11 error message
 #[derive(Debug)]
 struct XError(String);
 
@@ -175,7 +176,6 @@ mod test {
 	fn test_text_width() {
 		setup();
 		let ctx = Context::new("-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*").unwrap();
-
 		assert!(get_text_width(&ctx, "Hello World") > 0);
 	}
 	#[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate x11;
-
 use std::error::Error;
 use std::ffi::CString;
 use std::fmt;


### PR DESCRIPTION
Hi,
I saw the last commit was 2~ years ago so I'd like to propose this PR which contains a bunch of improvements:
* Create a custom error type (`XError`) and use with `Box<dyn std::error::Error>` instead of the deprecated `failure` crate.
* Add `with_misc()` method to `Context` for using the general misc-fixed font as default. (`-misc-fixed-*-*-*-*-*-*-*-*-*-*-*-*`)
* Replace the deprecated declarations with the up-to-date standards. (e.g: `mem::uninitialized()` -> `MaybeUninit::uninit()`)
* Avoid `mem::transmute` and use `MaybeUninit` instead.
* Add `rustfmt.toml` and apply formatting.
* Use Rust 2018 edition in `Cargo.toml`
* Upgrade the `x11` dependency in `Cargo.toml`
* Bump version to `1.2.0`
