### PR TITLE
Use thiserror for error implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 x11 = { version = "2.18.2", features = ["xlib"] }
+thiserror = "1"


### PR DESCRIPTION
This PR builds on #1 - so please wait with merging until #1 is merged!

It adds a patch to change the rustfmt setting back to spaces and then reimplements the `XError` type with `thiserror`.

The first patch might get picked to #1 ! :smile: 